### PR TITLE
Add question link and support for default tags

### DIFF
--- a/src/components/answer.vue
+++ b/src/components/answer.vue
@@ -67,7 +67,7 @@ export default {
     getBlogBody: function () {
       return md2html(this.blog.body,
         this.$store.getters['quearn/xss'],
-        this.$store.getters['quearn/config'].post_addon_msg)
+        this.$store.getters['quearn/removePatterns'])
     },
     onCommentCompleted: function (context) {
       context.writecomment = false

--- a/src/components/editblog.vue
+++ b/src/components/editblog.vue
@@ -194,6 +194,15 @@ export default {
       })
 
       let body = vue.form.body
+
+      if (!vue.isquestion) {
+        let url = require('url')
+        let q = url.parse(document.location.origin, true)
+        let questionUrl = 'https://' + q.hostname + '/question/' + vue.question_author + '/' + vue.question_permlink
+        body = '**' + vue.$store.getters['quearn/config'].appName + ' Notice:** *' + vue.$tc('linktoquestion') + '*\n\n' + body
+        body = body.replace(/@LINK/, questionUrl)
+      }
+
       if (vue.$store.getters['quearn/config'].post_addon_msg.length) {
         body += '\n\n' + vue.$store.getters['quearn/config'].post_addon_msg
       }
@@ -331,7 +340,7 @@ export default {
     compiledMarkdown: function () {
       return md2html(this.input,
         this.$store.getters['quearn/xss'],
-        this.$store.getters['quearn/config'].post_addon_msg)
+        this.$store.getters['quearn/removePatterns'])
     }
   },
   beforeDestroy: function () {

--- a/src/components/editblog.vue
+++ b/src/components/editblog.vue
@@ -372,13 +372,17 @@ export default {
       this.$refs.topicpicker.ternaryTopic = this.$q.localStorage.get.item('answerternaryTopic')
     }
 
-    if (form) {
-      this.form = form
-      if (!this.form.additionalTags) {
-        this.form.additionalTags = []
-      }
-      this.input = form.body
-    } else {
+    this.form = form
+    if (!this.form.additionalTags) {
+      this.form.additionalTags = []
+    }
+    this.input = form.body
+
+    if (this.$store.getters['quearn/config'].default_tags && this.form.additionalTags.length === 0) {
+      this.form.additionalTags = this.$store.getters['quearn/config'].default_tags.split()
+      this.form.additionalTags = this.form.additionalTags.map(function (item) {
+        return item.trim()
+      })
     }
   }
 }

--- a/src/components/utils/markdown.js
+++ b/src/components/utils/markdown.js
@@ -1,4 +1,4 @@
-export function md2html (str, xss, addonMsg) {
+export function md2html (str, xss, removePatterns) {
   if (!str) {
     return
   }
@@ -8,8 +8,9 @@ export function md2html (str, xss, addonMsg) {
     html: true,
     linkify: false
   })
-  if (addonMsg && addonMsg.length) {
-    str = str.replace(addonMsg, '')
+
+  for (let pattern of removePatterns) {
+    str = str.replace(pattern, '')
   }
 
   str = xss.process(md.render(str))

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -31,6 +31,7 @@ export default {
   latest: 'Latest',
   latestanswers: 'Latest answers',
   latestquestions: 'Latest questions',
+  linktoquestion: 'The following is an answer to [this question](@LINK)',
   login: 'Login',
   logout: 'Logout',
   maintext: 'Main Text',

--- a/src/i18n/fr/index.js
+++ b/src/i18n/fr/index.js
@@ -30,6 +30,7 @@ export default {
   latest: 'Recent',
   latestanswers: 'Reponses recentes',
   latestquestions: 'Questions recentes',
+  linktoquestion: 'Cet article est une reponse a [cette question](@LINK).',
   login: 'Se connecter',
   logout: 'Se deconnecter',
   maintext: 'Votre Texte',

--- a/src/pages/answer.vue
+++ b/src/pages/answer.vue
@@ -127,7 +127,7 @@ export default {
       } else {
         return md2html(this.blog.body,
           this.$store.getters['quearn/xss'],
-          this.$store.getters['quearn/config'].post_addon_msg)
+          this.$store.getters['quearn/removePatterns'])
       }
     },
     onCommentCompleted: function (context) {

--- a/src/pages/bookmarks.vue
+++ b/src/pages/bookmarks.vue
@@ -141,7 +141,7 @@ export default {
     getBlogBody: function (blog) {
       return md2html(blog.body,
         this.$store.getters['quearn/xss'],
-        this.$store.getters['quearn/config'].post_addon_msg)
+        this.$store.getters['quearn/removePatterns'])
     }
   },
   mounted () {

--- a/src/pages/news.vue
+++ b/src/pages/news.vue
@@ -69,7 +69,7 @@ export default {
     getBlogBody: function (blog) {
       return md2html(blog.body,
         this.$store.getters['quearn/xss'],
-        this.$store.getters['quearn/config'].post_addon_msg)
+        this.$store.getters['quearn/removePatterns'])
     },
     getNews: function (sources) {
       let dsteem = this.$store.getters['steem/dsteem']

--- a/src/pages/question.vue
+++ b/src/pages/question.vue
@@ -145,7 +145,7 @@ export default {
       } else {
         return md2html(this.blog.body,
           this.$store.getters['quearn/xss'],
-          this.$store.getters['quearn/config'].post_addon_msg)
+          this.$store.getters['quearn/removePatterns'])
       }
     },
     onAnswerCompleted: function (reload) {

--- a/src/pages/useranswers.vue
+++ b/src/pages/useranswers.vue
@@ -121,7 +121,7 @@ export default {
     getBlogBody: function (blog) {
       return md2html(blog.body,
         this.$store.getters['quearn/xss'],
-        this.$store.getters['quearn/config'].post_addon_msg)
+        this.$store.getters['quearn/removePatterns'])
     }
   },
   mounted () {

--- a/src/pages/userquestions.vue
+++ b/src/pages/userquestions.vue
@@ -134,7 +134,7 @@ export default {
     getBlogBody: function (blog) {
       return md2html(blog.body,
         this.$store.getters['quearn/xss'],
-        this.$store.getters['quearn/config'].post_addon_msg)
+        this.$store.getters['quearn/removePatterns'])
     }
   },
   mounted () {

--- a/src/plugins/quearn.js
+++ b/src/plugins/quearn.js
@@ -25,6 +25,8 @@ export default ({ store, Vue }) => {
       let config = response.data[0]
       store.commit('quearn/config', config)
       // document.title = config.appName
+
+      store.commit('quearn/removePatterns', new RegExp('\\*\\*' + config.appName + ' [Nn]otice:.*\n*', 'g'))
     }).catch(
     function (error) {
       console.log(error)

--- a/src/store/quearn/getters.js
+++ b/src/store/quearn/getters.js
@@ -14,6 +14,10 @@ export const config = (state) => {
   return state.config
 }
 
+export const removePatterns = (state) => {
+  return state.removePatterns
+}
+
 export const xss = (state) => {
   return state.xss
 }

--- a/src/store/quearn/mutations.js
+++ b/src/store/quearn/mutations.js
@@ -6,6 +6,10 @@ export const config = (state, config) => {
   state.config = config
 }
 
+export const removePatterns = (state, pattern) => {
+  state.removePatterns.push(pattern)
+}
+
 export const xss = (state, xss) => {
   state.xss = xss
 }

--- a/src/store/quearn/state.js
+++ b/src/store/quearn/state.js
@@ -5,6 +5,7 @@ export default {
   topics: null,
   favouriteTopicsById: null,
   xss: null,
+  removePatterns: [],
   bookmarksByQuestion: {
     type: Object
   }


### PR DESCRIPTION
This pull request adds support for including a link to the question post at the start of an answer.
This link will not be shown on StemQ but will be shown on other Steem apps.

This feature was combined with a refactoring of the post addon message which was already shown at the end of questions and answers.

Also, StemQ can now be configured with a comma separated list of default tags which will be offered to the user upon question/answer submission.
It is expected that StemQ will have the steemstem tag configured 